### PR TITLE
Schema mapping key invariance fix

### DIFF
--- a/jsonschema_path/accessors.py
+++ b/jsonschema_path/accessors.py
@@ -4,11 +4,11 @@ from collections import deque
 from contextlib import contextmanager
 from typing import Any
 from typing import Deque
-from typing import Hashable
 from typing import Iterator
 from typing import List
 from typing import Optional
 from typing import Union
+from typing import cast
 
 from pathable.accessors import LookupAccessor
 from referencing import Registry
@@ -27,8 +27,16 @@ from jsonschema_path.utils import is_ref
 
 class ResolverAccessor(LookupAccessor):
     def __init__(self, lookup: Lookup, resolver: Resolver[Lookup]):
-        super().__init__(lookup)
+        super().__init__(cast(Any, lookup))
         self.resolver = resolver
+
+    def stat(self, parts: List[Any]) -> dict[str, Any]:
+        d: Any = self.lookup
+        for part in parts:
+            if not isinstance(d, dict) or part not in d:
+                return {"exists": False}
+            d = cast(Any, d[part])
+        return {"exists": True}
 
 
 class SchemaAccessor(ResolverAccessor):
@@ -38,8 +46,10 @@ class SchemaAccessor(ResolverAccessor):
         schema: Schema,
         specification: Specification[Schema] = DRAFT202012,
         base_uri: str = "",
-        handlers: ResolverHandlers = default_handlers,
+        handlers: Optional[ResolverHandlers] = None,
     ) -> "SchemaAccessor":
+        if handlers is None:
+            handlers = default_handlers
         retriever = SchemaRetriever(handlers, specification)
         base_resource = specification.create_resource(schema)
         registry: Registry[Schema] = Registry(
@@ -50,26 +60,28 @@ class SchemaAccessor(ResolverAccessor):
         return cls(schema, resolver)
 
     @contextmanager
-    def open(self, parts: List[Hashable]) -> Iterator[Union[Schema, Any]]:
+    def open(self, parts: List[Any]) -> Iterator[Union[Schema, Any]]:
+        # Override signature to match LookupAccessor: List[Hashable] -> List[Any]
         parts_deque = deque(parts)
         try:
-            resolved = self._resolve(self.lookup, parts_deque)
+            resolved = self._resolve(cast(Schema, self.lookup), parts_deque)
             yield resolved.contents
         finally:
             pass
 
     @contextmanager
-    def resolve(self, parts: List[Hashable]) -> Iterator[Resolved[Any]]:
+    def resolve(self, parts: list[Any]) -> Iterator[Resolved[Any]]:
+        # Accepts list[Any] for compatibility with AccessorPath usage
         parts_deque = deque(parts)
         try:
-            yield self._resolve(self.lookup, parts_deque)
+            yield self._resolve(cast(Schema, self.lookup), parts_deque)
         finally:
             pass
 
     def _resolve(
         self,
         contents: Schema,
-        parts_deque: Deque[Hashable],
+        parts_deque: Deque[str],
         resolver: Optional[Resolver[Schema]] = None,
     ) -> Resolved[Any]:
         resolver = resolver or self.resolver

--- a/jsonschema_path/readers.py
+++ b/jsonschema_path/readers.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 from typing import Any
-from typing import Hashable
 from typing import Mapping
 from typing import Tuple
 
@@ -12,7 +11,7 @@ from jsonschema_path.handlers.protocols import SupportsRead
 
 
 class BaseReader:
-    def read(self) -> Tuple[Mapping[Hashable, Any], str]:
+    def read(self) -> Tuple[Mapping[str, Any], str]:
         raise NotImplementedError
 
 
@@ -20,7 +19,7 @@ class FileReader(BaseReader):
     def __init__(self, fileobj: SupportsRead):
         self.fileobj = fileobj
 
-    def read(self) -> Tuple[Mapping[Hashable, Any], str]:
+    def read(self) -> Tuple[Mapping[str, Any], str]:
         return file_handler(self.fileobj), ""
 
 
@@ -28,7 +27,7 @@ class PathReader(BaseReader):
     def __init__(self, path: Path):
         self.path = path
 
-    def read(self) -> Tuple[Mapping[Hashable, Any], str]:
+    def read(self) -> Tuple[Mapping[str, Any], str]:
         if not self.path.is_file():
             raise OSError(f"No such file: {self.path}")
 

--- a/jsonschema_path/typing.py
+++ b/jsonschema_path/typing.py
@@ -1,8 +1,7 @@
 from typing import Any
-from typing import Hashable
 from typing import Mapping
 
-Lookup = Mapping[Hashable, Any]
+Lookup = Mapping[str, Any]
 
 ResolverHandlers = Mapping[str, Any]
-Schema = Mapping[Hashable, Any]
+Schema = Mapping[str, Any]

--- a/jsonschema_path/utils.py
+++ b/jsonschema_path/utils.py
@@ -1,8 +1,7 @@
 from typing import Any
-from typing import Hashable
 from typing import Mapping
 from typing import Optional
 
 
-def is_ref(item: Optional[Mapping[Hashable, Any]]) -> bool:
+def is_ref(item: Optional[Mapping[str, Any]]) -> bool:
     return isinstance(item, dict) and "$ref" in item and item["$ref"].__hash__


### PR DESCRIPTION
Fixes #155

In the context of JSON Schema, all object keys are always strings.
