### PR TITLE
Schema accessor getitem return fix

### DIFF
--- a/jsonschema_path/accessors.py
+++ b/jsonschema_path/accessors.py
@@ -53,13 +53,8 @@ class SchemaAccessor(LookupAccessor):
         resolver = registry.resolver(base_uri=base_uri)
         return cls(schema, resolver)
 
-    def __getitem__(self, parts: Sequence[LookupKey]) -> None:
-        """Validate that the node at `parts` exists.
-
-        This performs a traversal only and raises `KeyError` (with the failing
-        part when available) if the path is missing or non-traversable.
-        """
-        self._get_node(self.node, parts, self.resolver)
+    def __getitem__(self, parts: Sequence[LookupKey]) -> LookupNode:
+        return self._get_node(self.node, parts, self.resolver)
 
     def stat(self, parts: Sequence[Hashable]) -> Optional[dict[str, Any]]:
         try:

--- a/poetry.lock
+++ b/poetry.lock
@@ -791,14 +791,14 @@ testing = ["docopt", "pytest"]
 
 [[package]]
 name = "pathable"
-version = "0.5.0b5"
+version = "0.5.0b6"
 description = "Object-oriented paths"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "pathable-0.5.0b5-py3-none-any.whl", hash = "sha256:6f94d89257a065f2f06ed72142e0d112433aaaa93e534264c91f7065fa3e7e9c"},
-    {file = "pathable-0.5.0b5.tar.gz", hash = "sha256:5459350562b978de2ad4f5f7254963e9ca8b0d60cff3d3bb5e293e2148bb4f4a"},
+    {file = "pathable-0.5.0b6-py3-none-any.whl", hash = "sha256:c66bafb0e93b790098e580a1c89e042a24148d6541098f18d24ae1fc77e1b335"},
+    {file = "pathable-0.5.0b6.tar.gz", hash = "sha256:a36763b534a213894ddbca01db5b869aca52779e89a193078304fb3706b94404"},
 ]
 
 [[package]]

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -129,3 +129,22 @@ class TestSchemaPathFromFilePath:
         sp = SchemaPath.from_file_path(schema_file_path_str)
 
         assert_sp(sp, schema, base_uri=schema_file_uri)
+
+
+class TestSchemaPathGetkey:
+    def test_returns_node(self, create_file):
+        schema = {"a": {"b": 1}}
+        schema_file_path_str = create_file(schema)
+        sp = SchemaPath.from_file_path(schema_file_path_str)
+
+        node = sp.getkey("a")
+        assert isinstance(node, SchemaPath)
+        assert node.parts == ("a",)
+
+    def test_returns_value(self, create_file):
+        schema = {"a": {"b": 1}}
+        schema_file_path_str = create_file(schema)
+        sp = SchemaPath.from_file_path(schema_file_path_str) // "a"
+
+        value = sp.getkey("b")
+        assert value == 1


### PR DESCRIPTION
This pull request makes improvements to the `SchemaPath` class and its test coverage, mainly focusing on how keys are accessed and validated. The most significant change is modifying the `__getitem__` method to return the node at the specified path, and adding new tests for key access behavior.

Enhancements to key access and validation:

* Modified the `__getitem__` method in `SchemaPath` to return the node found at the given path instead of just validating its existence. Now, it returns the actual node, improving usability and consistency with typical Python container behavior.

Test coverage improvements:

* Added a new test class `TestSchemaPathGetkey` to verify the behavior of the `getkey` method, including tests for returning a `SchemaPath` node and for returning a value at a nested key.