### PR TITLE
SchemaPath getkey return nested value fix

### DIFF
--- a/jsonschema_path/paths.py
+++ b/jsonschema_path/paths.py
@@ -174,11 +174,11 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
     ) -> SchemaValue | TDefault: ...
 
     def getkey(self, key: SchemaKey, default: object = None) -> object:
-        warnings.warn(
-            "'getkey' method is deprecated. Use 'get' instead.",
-            DeprecationWarning,
-        )
-        return self.get(key, default=default)
+        try:
+            path = self // key
+        except KeyError:
+            return default
+        return path.read_value()
 
     def as_uri(self) -> str:
         return f"#/{str(self)}"

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -132,14 +132,13 @@ class TestSchemaPathFromFilePath:
 
 
 class TestSchemaPathGetkey:
-    def test_returns_node(self, create_file):
+    def test_returns_nested_value(self, create_file):
         schema = {"a": {"b": 1}}
         schema_file_path_str = create_file(schema)
         sp = SchemaPath.from_file_path(schema_file_path_str)
 
-        node = sp.getkey("a")
-        assert isinstance(node, SchemaPath)
-        assert node.parts == ("a",)
+        value = sp.getkey("a")
+        assert value == {"b": 1}
 
     def test_returns_value(self, create_file):
         schema = {"a": {"b": 1}}


### PR DESCRIPTION
This pull request updates the behavior of the `getkey` method in `SchemaPath` to return the nested value directly instead of a `SchemaPath` object, and removes its deprecation warning. Corresponding unit tests are updated to reflect this new behavior.

### `SchemaPath.getkey` method changes

- Changed `getkey` to return the value at the specified key directly (using `read_value()`), and removed the deprecation warning that advised using `get` instead.

### Test updates

- Updated the unit test `test_returns_node` (now `test_returns_nested_value`) to assert that `getkey` returns the nested value, not a `SchemaPath` instance.