### PR TITLE
SchemaPath typing helper methods

### DIFF
--- a/jsonschema_path/typing.py
+++ b/jsonschema_path/typing.py
@@ -1,5 +1,12 @@
+import sys
 from typing import Any
 from typing import Mapping
+from typing import Sequence
+
+if sys.version_info >= (3, 10):
+    from typing import TypeGuard
+else:
+    from typing_extensions import TypeGuard
 
 from pathable.types import LookupKey as SchemaKey
 from pathable.types import LookupNode as SchemaNode
@@ -15,3 +22,8 @@ __all__ = [
 
 ResolverHandlers = Mapping[str, Any]
 Schema = Mapping[str, Any]
+
+
+def is_str_sequence(val: Sequence[object]) -> TypeGuard[Sequence[str]]:
+    """Determines whether all objects in the list are strings"""
+    return all(isinstance(x, str) for x in val)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1469,6 +1469,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
+markers = {main = "python_version < \"3.13\""}
 
 [[package]]
 name = "unidecode"
@@ -1544,4 +1545,4 @@ requests = ["requests"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.0,<4.0.0"
-content-hash = "252e1716c7f466db2d9644b40950370f02994e7cb7e4d594b2dfb6a8aaa645d9"
+content-hash = "2e8575b9e8428a286dabf6c103c6a694c861a99681b26f593485b3e991eb4104"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ python = ">=3.9.0,<4.0.0"
 PyYAML = ">=5.1"
 requests = {version = "^2.31.0", optional = true}
 referencing = "<0.37.0"
+typing-extensions = {version = "^4.10.0", python = "<3.10"}
 
 [tool.poetry.group.dev.dependencies]
 tbump = "^6.11.0"
@@ -59,7 +60,6 @@ flynt = "1.0.2"
 mypy = "^1.14.1"
 types-PyYAML = "^6.0.12"
 types-requests = "^2.31.0"
-typing-extensions = "^4.10.0"  # required by responses. See https://github.com/p1c2u/jsonschema-path/issues/44
 responses = "^0.25.0"
 deptry = ">=0.19.1,<0.24.0"
 pyflakes = ">=2.5,<4.0"

--- a/tests/integration/test_schema_path.py
+++ b/tests/integration/test_schema_path.py
@@ -336,30 +336,3 @@ class TestSchemaPathOpen:
             assert resolved.contents == expected_contents
         with property_schema_path.open() as contents:
             assert contents == expected_contents
-
-
-class TestSchemaPathContents:
-    def test_dict(self, defs):
-        schema = {
-            "properties": {
-                "info": {
-                    "$ref": "#/$defs/Info",
-                },
-            },
-            "$defs": defs,
-        }
-        path = SchemaPath.from_dict(schema)
-
-        assert "properties" in path
-
-        info_path = path / "properties" / "info"
-
-        assert "properties" in info_path
-
-        version_path = info_path / "properties" / "version"
-
-        expected_contents = {"type": "string", "default": "1.0"}
-
-        contents = version_path.contents()
-
-        assert contents == expected_contents


### PR DESCRIPTION
This pull request introduces several enhancements and cleanups to the `SchemaPath` class and its related tests, focusing on improved type-safe value accessors, better argument parsing, and removal of deprecated interfaces. The most significant changes include the addition of `read_str` and `read_bool` methods for type-checked value retrieval, updates to argument parsing logic, and expanded test coverage for these new features.

**Enhancements to SchemaPath API:**

* Added `read_str` and `read_bool` methods to `SchemaPath` for type-checked retrieval of string and boolean values, supporting optional defaults and raising appropriate exceptions on type mismatch or missing keys.
* Introduced helper methods `str_keys` and `str_items` to provide string-keyed access to child paths.
* Deprecated and removed the old `contents` method in favor of `read_value`. [[1]](diffhunk://#diff-44475451de9b8d98dec4dc5209ce1ad8105d128e7273e9b97efa8ebc7b64f64cL161-R202) [[2]](diffhunk://#diff-12a3bb1cc6032a8b7ef4126ffb40f119564b34bc47d92c6ea228e8c95b7efb31L339-L365)

**Argument parsing improvements:**

* Enhanced `_parse_args` to accept `bytes` and `os.PathLike` objects, decoding or converting them as needed, and improved handling of empty and dot (`"."`) segments. [[1]](diffhunk://#diff-44475451de9b8d98dec4dc5209ce1ad8105d128e7273e9b97efa8ebc7b64f64cR63-R65) [[2]](diffhunk://#diff-44475451de9b8d98dec4dc5209ce1ad8105d128e7273e9b97efa8ebc7b64f64cL72-L74)

**Testing improvements:**

* Added comprehensive tests for `read_str`, `read_bool`, `str_keys`, `str_items`, `as_uri`, and `_parse_args`, ensuring correct behavior and error handling for the new and updated methods.
* Removed obsolete tests for the deprecated `contents` method.

**Internal constants:**

* Introduced a new `NOTSET` sentinel object for distinguishing between missing and explicitly provided default values.