### PR TITLE
SchemaPath read_str_or_list helper method

### DIFF
--- a/jsonschema_path/paths.py
+++ b/jsonschema_path/paths.py
@@ -192,6 +192,27 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
         return value
 
     @overload
+    def read_str_or_list(self) -> str | list[str]: ...
+
+    @overload
+    def read_str_or_list(
+        self, default: TDefault
+    ) -> str | list[str] | TDefault: ...
+
+    def read_str_or_list(self, default: object = NOTSET) -> object:
+        try:
+            value = self.read_value()
+        except KeyError:
+            if default is not NOTSET:
+                return default
+            raise
+        if not isinstance(value, (str, list)):
+            raise TypeError(
+                f"Expected a string or a list of strings, got {type(value)}"
+            )
+        return value
+
+    @overload
     def read_bool(self) -> bool: ...
 
     @overload

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -205,6 +205,36 @@ class TestSchemaPathReadBool:
         assert sp.read_bool(default=default) is default
 
 
+class TestSchemaPathReadStrOrList:
+    def test_returns_string_value(self):
+        sp = SchemaPath.from_dict({"value": "test"}) // "value"
+
+        assert sp.read_str_or_list() == "test"
+
+    def test_returns_list_value(self):
+        sp = SchemaPath.from_dict({"value": ["a", "b"]}) // "value"
+
+        assert sp.read_str_or_list() == ["a", "b"]
+
+    def test_missing_key_raises(self):
+        sp = SchemaPath.from_dict({})
+
+        with pytest.raises(KeyError):
+            (sp // "missing").read_str_or_list()
+
+    def test_missing_key_returns_default(self):
+        sp = SchemaPath.from_dict({})
+        default = mock.sentinel.default
+
+        assert (sp / "missing").read_str_or_list(default=default) is default
+
+    def test_non_string_or_list_raises(self):
+        sp = SchemaPath.from_dict({"value": 1}) // "value"
+
+        with pytest.raises(TypeError):
+            sp.read_str_or_list()
+
+
 class TestSchemaPathHelpers:
     def test_as_uri(self):
         sp = SchemaPath.from_dict({"a": {"b": 1}}) // "a" // "b"


### PR DESCRIPTION
This pull request introduces a new method for reading values as either a string or a list of strings from a `SchemaPath` object, along with comprehensive unit tests to ensure correct behavior and error handling.

### New feature: Reading string or list values

* Added the `read_str_or_list` method to the `SchemaPath` class in `jsonschema_path/paths.py`, allowing retrieval of values that may be either a string or a list of strings, with support for a default value.

### Testing and validation

* Added the `TestSchemaPathReadStrOrList` test class in `tests/unit/test_paths.py` to verify that `read_str_or_list` correctly handles string, list, missing, and invalid type cases, as well as the use of default values.