### PR TITLE
Referencing 0.37

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1082,14 +1082,14 @@ files = [
 
 [[package]]
 name = "referencing"
-version = "0.36.2"
+version = "0.37.0"
 description = "JSON Referencing + Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
-    {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
+    {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
+    {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
 ]
 
 [package.dependencies]
@@ -1529,4 +1529,4 @@ requests = ["requests"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0.0"
-content-hash = "34ac32d2e24ef8b04e14270237aa366382b9436987446cb47e1afec943549a04"
+content-hash = "59e5e7f68b8b556b88d889f7727a9c53a945e9cc54e22ea353915e8c544dd89a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pathable = "^0.5.0"
 python = ">=3.10,<4.0.0"
 PyYAML = ">=5.1"
 requests = {version = "^2.31.0", optional = true}
-referencing = "<0.37.0"
+referencing = "<0.38.0"
 
 [tool.poetry.group.dev.dependencies]
 tbump = "^6.11.0"


### PR DESCRIPTION
This pull request updates the `referencing` dependency in the `pyproject.toml` file to allow a newer version. This is a minor dependency update and does not affect any application code.

- Dependency update:
  * Relaxed the version constraint for the `referencing` package from `<0.37.0` to `<0.38.0` in `pyproject.toml` to allow for newer patch releases.

Fixes  #204
