### PR TITLE
Avoid unnecessary resolver evolution in get_resolved

### DIFF
--- a/jsonschema_path/accessors.py
+++ b/jsonschema_path/accessors.py
@@ -144,10 +144,11 @@ class SchemaAccessor(LookupAccessor):
 
     def get_resolved(self, parts: Sequence[LookupKey]) -> Resolved[LookupNode]:
         resolved = self._get_resolved(self.node, parts, resolver=self.resolver)
-        self.resolver = self.resolver._evolve(
-            self.resolver._base_uri,
-            registry=resolved.resolver._registry,
-        )
+        if resolved.resolver._registry is not self.resolver._registry:
+            self.resolver = self.resolver._evolve(
+                self.resolver._base_uri,
+                registry=resolved.resolver._registry,
+            )
         return resolved
 
     @classmethod


### PR DESCRIPTION
- Biggest wins are in lookup-heavy paths:
  - schema.contains.mapping.*: ~1.41x (about +41%)
  - schema.keys.mapping.*: ~1.39x to 1.41x
- Smaller but consistent gains:
  - schema.read_value.*: 1.03x to 1.04x
  - schema.iter_children.mapping.*: slight improvement (1.006x to 1.129x)
- Tiny slowdowns only in cache-hit open scenarios:
  - schema.open.cache_hit.*: 0.993x to 0.994x (~0.6–0.7% slower), essentially noise-level.

Given tolerance 0.20, none of the regressions are remotely close to failing (0.80x threshold), and the net effect is strongly favorable.

Fixes #238
