### PR TITLE
Add optional resolved-path LRU cache with safe invalidation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,21 @@ Usage
    {'type': 'string', 'default': '1.0'}
 
 
+Resolved cache
+##############
+
+The resolved-path cache is intended for repeated path lookups and may significantly improve
+``read_value``/membership hot paths. Cache entries are invalidated when the
+resolver registry evolves during reference resolution.
+
+This cache is optional and disabled by default
+(``resolved_cache_maxsize=0``). You can enable it when creating paths or
+accessors, for example:
+
+.. code-block:: python
+
+   >>> path = SchemaPath.from_dict(d, resolved_cache_maxsize=64)
+
 Benchmarks
 ##########
 
@@ -110,12 +125,13 @@ For a quick smoke run:
    poetry run python -m tests.benchmarks.bench_parse --output reports/bench-parse.quick.json --quick
    poetry run python -m tests.benchmarks.bench_lookup --output reports/bench-lookup.quick.json --quick
 
-You can also control repeats/warmup via env vars:
+You can also control repeats/warmup and resolved cache maxsize via env vars:
 
 .. code-block:: console
 
    export JSONSCHEMA_PATH_BENCH_REPEATS=5
    export JSONSCHEMA_PATH_BENCH_WARMUP=1
+   export JSONSCHEMA_PATH_BENCH_RESOLVED_CACHE_MAXSIZE=64
 
 Compare two results:
 

--- a/jsonschema_path/paths.py
+++ b/jsonschema_path/paths.py
@@ -105,6 +105,7 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
         specification: Specification[Schema] = DRAFT202012,
         base_uri: str = "",
         handlers: ResolverHandlers = default_handlers,
+        resolved_cache_maxsize: int = 0,
         spec_url: str | None = None,
         ref_resolver_handlers: ResolverHandlers | None = None,
     ) -> TSchemaPath:
@@ -127,6 +128,7 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
             specification=specification,
             base_uri=base_uri,
             handlers=handlers,
+            resolved_cache_maxsize=resolved_cache_maxsize,
         )
 
         return cls(accessor, *args, separator=separator)
@@ -135,19 +137,29 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
     def from_path(
         cls: type[TSchemaPath],
         path: Path,
+        resolved_cache_maxsize: int = 0,
     ) -> TSchemaPath:
         reader = PathReader(path)
         data, base_uri = reader.read()
-        return cls.from_dict(data, base_uri=base_uri)
+        return cls.from_dict(
+            data,
+            base_uri=base_uri,
+            resolved_cache_maxsize=resolved_cache_maxsize,
+        )
 
     @classmethod
     def from_file_path(
         cls: type[TSchemaPath],
         file_path: str,
+        resolved_cache_maxsize: int = 0,
     ) -> TSchemaPath:
         reader = FilePathReader(file_path)
         data, base_uri = reader.read()
-        return cls.from_dict(data, base_uri=base_uri)
+        return cls.from_dict(
+            data,
+            base_uri=base_uri,
+            resolved_cache_maxsize=resolved_cache_maxsize,
+        )
 
     @classmethod
     def from_file(
@@ -155,10 +167,16 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
         fileobj: SupportsRead,
         base_uri: str = "",
         spec_url: str | None = None,
+        resolved_cache_maxsize: int = 0,
     ) -> TSchemaPath:
         reader = FileReader(fileobj)
         data, _ = reader.read()
-        return cls.from_dict(data, base_uri=base_uri, spec_url=spec_url)
+        return cls.from_dict(
+            data,
+            base_uri=base_uri,
+            spec_url=spec_url,
+            resolved_cache_maxsize=resolved_cache_maxsize,
+        )
 
     def str_keys(self) -> Sequence[str]:
         keys = list(self.keys())

--- a/tests/benchmarks/bench_utils.py
+++ b/tests/benchmarks/bench_utils.py
@@ -54,6 +54,22 @@ def _safe_int_env(name: str) -> int | None:
         return None
 
 
+def safe_nonnegative_int_env(name: str, *, default: int = 0) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+    if parsed < 0:
+        raise ValueError(f"{name} must be >= 0")
+
+    return parsed
+
+
 def default_meta() -> dict[str, Any]:
     return {
         "python": sys.version,

--- a/tests/unit/test_paths.py
+++ b/tests/unit/test_paths.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from referencing import Specification
 
+from jsonschema_path.accessors import SchemaAccessor
 from jsonschema_path.paths import SchemaPath
 
 
@@ -46,6 +47,15 @@ class TestSchemaPathFromDict:
         sp = SchemaPath.from_dict(schema, handlers=handlers)
 
         assert_sp(sp, schema, handlers=handlers)
+
+    def test_resolved_cache_maxsize(self):
+        sp = SchemaPath.from_dict(
+            {"name": "test"},
+            resolved_cache_maxsize=3,
+        )
+
+        assert isinstance(sp.accessor, SchemaAccessor)
+        assert sp.accessor._resolved_cache_maxsize == 3
 
     def test_spec_url(self, assert_sp):
         schema = mock.sentinel.schema
@@ -100,6 +110,20 @@ class TestSchemaPathFromFile:
 
         assert_sp(sp, schema, base_uri=spec_url)
 
+    def test_resolved_cache_maxsize(self, create_file):
+        schema = {"type": "integer"}
+        schema_file_path_str = create_file(schema)
+        schema_file_path = Path(schema_file_path_str)
+        schema_file_obj = schema_file_path.open()
+
+        sp = SchemaPath.from_file(
+            schema_file_obj,  # type: ignore[arg-type]
+            resolved_cache_maxsize=3,
+        )
+
+        assert isinstance(sp.accessor, SchemaAccessor)
+        assert sp.accessor._resolved_cache_maxsize == 3
+
 
 class TestSchemaPathFromPath:
     def test_file_no_exist(self, create_file):
@@ -119,6 +143,19 @@ class TestSchemaPathFromPath:
 
         assert_sp(sp, schema, base_uri=schema_file_uri)
 
+    def test_resolved_cache_maxsize(self, create_file):
+        schema = {"type": "integer"}
+        schema_file_path_str = create_file(schema)
+        schema_file_path = Path(schema_file_path_str)
+
+        sp = SchemaPath.from_path(
+            schema_file_path,
+            resolved_cache_maxsize=3,
+        )
+
+        assert isinstance(sp.accessor, SchemaAccessor)
+        assert sp.accessor._resolved_cache_maxsize == 3
+
 
 class TestSchemaPathFromFilePath:
     def test_no_kwargs(self, create_file, assert_sp):
@@ -129,6 +166,18 @@ class TestSchemaPathFromFilePath:
         sp = SchemaPath.from_file_path(schema_file_path_str)
 
         assert_sp(sp, schema, base_uri=schema_file_uri)
+
+    def test_resolved_cache_maxsize(self, create_file):
+        schema = {"type": "integer"}
+        schema_file_path_str = create_file(schema)
+
+        sp = SchemaPath.from_file_path(
+            schema_file_path_str,
+            resolved_cache_maxsize=3,
+        )
+
+        assert isinstance(sp.accessor, SchemaAccessor)
+        assert sp.accessor._resolved_cache_maxsize == 3
 
 
 class TestSchemaPathGetkey:


### PR DESCRIPTION
- Lookup benchmark (bench_lookup) shows very strong gains with cache enabled:
  - schema.read_value.local_ref.depth25: 46.123x
  - schema.read_value.plain.depth25: 36.917x
  - schema.contains.mapping.size50000: 6.601x
  - schema.keys.mapping.size50000: 5.627x
  - schema.open.cache_hit.*: small gains (1.017x / 1.028x)

- Parse benchmark (bench_parse) is mostly unchanged (as expected)