### PR TITLE
Resolved cache enabled and SchemaPath per-instance cache removed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,13 +97,35 @@ The resolved-path cache is intended for repeated path lookups and may significan
 ``read_value``/membership hot paths. Cache entries are invalidated when the
 resolver registry evolves during reference resolution.
 
-This cache is optional and disabled by default
-(``resolved_cache_maxsize=0``). You can enable it when creating paths or
+This cache is enabled by default
+(``resolved_cache_maxsize=128``). You can disable it when creating paths or
 accessors, for example:
 
 .. code-block:: python
 
-   >>> path = SchemaPath.from_dict(d, resolved_cache_maxsize=64)
+   >>> path = SchemaPath.from_dict(d, resolved_cache_maxsize=0)
+
+Build **one** :code:`SchemaAccessor` per schema document and reuse it for
+every :code:`SchemaPath` you derive from that document. Treat the accessor
+as the long-lived handle to the resource; treat paths as cheap views over
+it.
+
+.. code-block:: python
+
+   >>> from jsonschema_path import SchemaPath
+   >>> from jsonschema_path.accessors import SchemaAccessor
+
+   >>> # Construct the accessor once, with caching enabled.
+   >>> accessor = SchemaAccessor.from_schema(d, resolved_cache_maxsize=128)
+
+   >>> # Derive as many paths as you like from the same accessor.
+   >>> root = SchemaPath(accessor)
+   >>> info = root / "properties" / "info"
+   >>> version = info / "properties" / "version"
+
+   >>> # Every path over `accessor` shares the same resolved-ref cache.
+   >>> with version.open() as contents:
+   ...     ...
 
 Benchmarks
 ##########

--- a/jsonschema_path/accessors.py
+++ b/jsonschema_path/accessors.py
@@ -31,7 +31,7 @@ class SchemaAccessor(LookupAccessor):
         self,
         schema: Schema,
         resolver: Resolver[Schema],
-        resolved_cache_maxsize: int = 0,
+        resolved_cache_maxsize: int = 128,
     ):
         if resolved_cache_maxsize < 0:
             raise ValueError("resolved_cache_maxsize must be >= 0")

--- a/jsonschema_path/paths.py
+++ b/jsonschema_path/paths.py
@@ -7,7 +7,6 @@ import warnings
 from collections.abc import Iterator
 from collections.abc import Sequence
 from contextlib import contextmanager
-from functools import cached_property
 from pathlib import Path
 from typing import Any
 from typing import TypeVar
@@ -260,18 +259,12 @@ class SchemaPath(AccessorPath[SchemaNode, SchemaKey, SchemaValue]):
     @contextmanager
     def open(self) -> Any:
         """Open the path."""
-        # Cached path content
         with self.resolve() as resolved:
             yield resolved.contents
 
     @contextmanager
     def resolve(self) -> Iterator[Resolved[SchemaNode]]:
         """Resolve the path."""
-        # Cached path content
-        yield self._get_resolved
-
-    @cached_property
-    def _get_resolved(self) -> Resolved[SchemaNode]:
         assert isinstance(self.accessor, SchemaAccessor)
         with self.accessor.resolve(self.parts) as resolved:
-            return resolved
+            yield resolved


### PR DESCRIPTION
Also the correctness fix (the per-instance cache never invalidated on registry evolution, and it cached a Resolved after the accessor's context manager had already exited)