### PR TITLE
Resolved cache evolution rebind

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,8 +94,13 @@ Resolved cache
 ##############
 
 The resolved-path cache is intended for repeated path lookups and may significantly improve
-``read_value``/membership hot paths. Cache entries are invalidated when the
-resolver registry evolves during reference resolution.
+``read_value``/membership hot paths. When the underlying ``referencing``
+registry grows (e.g. an external ``$ref`` pulls in a new document),
+cached entries are *rebound* to the new registry on read instead of
+being discarded. This relies on registries growing monotonically —
+resources are added, never replaced. Handlers that return drifting
+content for the same URI violate that assumption; disable caching with
+``resolved_cache_maxsize=0`` if you need to defend against it.
 
 This cache is enabled by default
 (``resolved_cache_maxsize=128``). You can disable it when creating paths or

--- a/jsonschema_path/_referencing_compat.py
+++ b/jsonschema_path/_referencing_compat.py
@@ -1,0 +1,122 @@
+"""Compatibility shim for the ``referencing`` library's private API.
+
+This module is the *only* place in jsonschema-path that touches
+``referencing._core`` internals (the ``_base_uri``, ``_registry``, and
+``_previous`` attributes on ``Resolver``). Every other module must go
+through the helpers here.
+
+The motivation is firewalling: if a future ``referencing`` release
+reshapes those internals, the breakage is contained to this file. The
+``assert_referencing_layout`` call at import time also converts what
+would otherwise be silent wrong-results into a loud ``ImportError`` that
+names the issue, so version-skew bugs surface immediately.
+
+The helpers intentionally use ``Any``-typed generics because
+``referencing`` does not expose ``Resolver`` / ``Resolved`` as
+``attrs``-typed classes to type checkers, and ``Resolver._evolve``
+itself is declared ``**kwargs: Any``. The runtime invariants are
+enforced by ``assert_referencing_layout``; ``mypy`` is asked to trust
+this single module.
+
+Supported ``referencing`` versions: the upper bound is pinned in
+``pyproject.toml``; the lower bound is implied by these internals being
+``attrs`` fields named ``_base_uri``, ``_registry``, and ``_previous``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import Union
+
+import attrs
+from referencing import Registry
+from referencing._core import Resolved
+from referencing._core import Resolver
+
+ResolvedOrResolver = Union[Resolved[Any], Resolver[Any]]
+
+_REQUIRED_RESOLVER_FIELDS = frozenset({"_base_uri", "_registry", "_previous"})
+
+
+def assert_referencing_layout() -> None:
+    """Verify ``referencing.Resolver`` exposes the attrs fields we rebind.
+
+    Called once at import time. Raises ``ImportError`` if the installed
+    ``referencing`` is incompatible, instead of allowing rebind operations
+    to silently produce wrong results.
+    """
+    fields = {
+        field.name
+        for field in attrs.fields(Resolver)  # type: ignore[arg-type]
+    }
+    missing = _REQUIRED_RESOLVER_FIELDS - fields
+    if missing:
+        raise ImportError(
+            "jsonschema-path is incompatible with the installed version "
+            "of `referencing`. Expected `Resolver` attrs fields to "
+            f"include {sorted(_REQUIRED_RESOLVER_FIELDS)}; missing "
+            f"{sorted(missing)}. Pin `referencing` to a supported "
+            "version (see jsonschema_path/_referencing_compat.py)."
+        )
+
+
+def rebind_registry(
+    resolver: Resolver[Any],
+    registry: Registry[Any],
+) -> Resolver[Any]:
+    """Return a new resolver identical to *resolver* but with *registry*.
+
+    ``referencing.Registry`` instances are immutable and grow
+    monotonically via ``with_resource``. A cached ``Resolver`` captured
+    before the registry grew can be cheaply rebound to the latest
+    registry without re-walking the schema, because:
+
+    * The resolver's ``base_uri`` describes a document scope that the
+      newer registry, being a superset, still contains.
+    * ``Resolver._previous`` holds URIs (not resolver snapshots), and
+      ``Resolver.dynamic_scope`` re-uses ``self._registry`` for every
+      frame, so swapping the top resolver's registry rebinds the entire
+      dynamic scope in one shot.
+
+    Uses ``attrs.evolve`` rather than ``Resolver._evolve`` because the
+    latter pushes onto the dynamic-scope stack when called with a
+    differing ``base_uri``. We want a pure field replacement.
+    """
+    return attrs.evolve(resolver, registry=registry)  # type: ignore[misc]
+
+
+def rebind_resolved(
+    resolved: Resolved[Any],
+    registry: Registry[Any],
+) -> Resolved[Any]:
+    """Return a new ``Resolved`` with the same ``contents`` but a
+    resolver rebound to *registry*.
+
+    Centralizing the ``Resolved(...)`` construction here keeps the
+    ``call-arg`` type-ignore confined to a single line — production
+    callers (``SchemaAccessor.get_resolved`` and
+    ``CachedPathResolver._resolve_with_prefix_cache``) work in terms of
+    this helper and don't have to construct ``Resolved`` themselves.
+    """
+    return Resolved(  # type: ignore[call-arg]
+        contents=resolved.contents,
+        resolver=rebind_registry(resolved.resolver, registry),
+    )
+
+
+def registry_of(target: ResolvedOrResolver) -> Registry[Any]:
+    """Return the registry backing a Resolved or Resolver."""
+    if isinstance(target, Resolved):
+        return target.resolver._registry
+    return target._registry
+
+
+def base_uri_of(target: ResolvedOrResolver) -> str:
+    """Return the base URI of a Resolved or Resolver."""
+    if isinstance(target, Resolved):
+        return target.resolver._base_uri
+    return target._base_uri
+
+
+# Verify referencing layout at import time so version-skew fails loud.
+assert_referencing_layout()

--- a/jsonschema_path/accessors.py
+++ b/jsonschema_path/accessors.py
@@ -18,6 +18,7 @@ from referencing._core import Resolved
 from referencing._core import Resolver
 from referencing.jsonschema import DRAFT202012
 
+from jsonschema_path._referencing_compat import rebind_resolved
 from jsonschema_path.caches import FullPathResolvedCache
 from jsonschema_path.handlers import default_handlers
 from jsonschema_path.resolvers import CachedPathResolver
@@ -176,12 +177,25 @@ class SchemaAccessor(LookupAccessor):
     def get_resolved(self, parts: Sequence[LookupKey]) -> Resolved[LookupNode]:
         cached_resolved = self._resolved_cache.get(parts)
         if cached_resolved is not None:
-            return cached_resolved
+            # Read `_registry` directly: it is a stable attrs-backed
+            # attribute on every supported referencing version (the
+            # import-time `assert_referencing_layout` guarantees this)
+            # and a plain attribute access is ~30ns vs ~100ns through a
+            # helper with isinstance dispatch. The cold-path field
+            # *write* still goes through `rebind_resolved`.
+            current_registry = self._path_resolver.resolver._registry
+            if cached_resolved.resolver._registry is current_registry:
+                return cached_resolved
+            # Rebind to the current registry rather than discard. Safe
+            # under monotonic registry growth (see caches.py docstring).
+            rebound = cast(
+                Resolved[LookupNode],
+                rebind_resolved(cached_resolved, current_registry),
+            )
+            self._resolved_cache.set(parts, rebound)
+            return rebound
 
         result = self._path_resolver.resolve(self.node, parts)
-        if result.registry_changed:
-            self._resolved_cache.invalidate()
-
         self._resolved_cache.set(parts, result.resolved)
 
         return result.resolved

--- a/jsonschema_path/caches.py
+++ b/jsonschema_path/caches.py
@@ -1,4 +1,15 @@
-"""JSONSchema path caches module."""
+"""JSONSchema path caches module.
+
+Both caches store ``Resolved`` values keyed on hashable schema paths.
+Staleness across ``referencing.Registry`` growth is *not* handled by
+invalidation here; the callers rebind cached ``Resolved`` values to the
+current registry on read (see
+``jsonschema_path._referencing_compat.rebind_registry``). This relies on
+the assumption that registries grow monotonically — resources are added,
+never replaced. Handlers that return drifting content for the same URI
+violate that assumption; users who need to defend against that should
+disable caching with ``resolved_cache_maxsize=0``.
+"""
 
 from collections import OrderedDict
 from collections.abc import Sequence
@@ -11,16 +22,15 @@ from referencing._core import Resolved
 class FullPathResolvedCache:
     def __init__(self, maxsize: int):
         self._maxsize = maxsize
-        self._generation = 0
         self._cache: OrderedDict[
-            tuple[tuple[LookupKey, ...], int],
+            tuple[LookupKey, ...],
             Resolved[LookupNode],
         ] = OrderedDict()
 
     def _make_key(
         self,
         parts: Sequence[LookupKey],
-    ) -> tuple[tuple[LookupKey, ...], int] | None:
+    ) -> tuple[LookupKey, ...] | None:
         if self._maxsize <= 0:
             return None
 
@@ -30,7 +40,7 @@ class FullPathResolvedCache:
         except TypeError:
             return None
 
-        return (parts_tuple, self._generation)
+        return parts_tuple
 
     def get(
         self,
@@ -61,10 +71,6 @@ class FullPathResolvedCache:
         if len(self._cache) > self._maxsize:
             self._cache.popitem(last=False)
 
-    def invalidate(self) -> None:
-        self._generation += 1
-        self._cache.clear()
-
 
 class PrefixResolvedCache:
     def __init__(self) -> None:
@@ -89,6 +95,19 @@ class PrefixResolvedCache:
 
         return None
 
+    def replace(
+        self,
+        parts: tuple[LookupKey, ...],
+        index: int,
+        resolved: Resolved[LookupNode],
+    ) -> None:
+        """Overwrite an existing prefix entry (used after a rebind)."""
+        prefix = parts[:index]
+        try:
+            self._cache[prefix] = resolved
+        except TypeError:
+            pass
+
     def store_intermediate(
         self,
         parts: tuple[LookupKey, ...],
@@ -103,6 +122,3 @@ class PrefixResolvedCache:
             self._cache[prefix] = resolved
         except TypeError:
             pass
-
-    def invalidate(self) -> None:
-        self._cache.clear()

--- a/jsonschema_path/resolvers.py
+++ b/jsonschema_path/resolvers.py
@@ -8,6 +8,8 @@ from referencing import Registry
 from referencing._core import Resolved
 from referencing._core import Resolver
 
+from jsonschema_path._referencing_compat import rebind_registry
+from jsonschema_path._referencing_compat import rebind_resolved
 from jsonschema_path.caches import PrefixResolvedCache
 from jsonschema_path.nodes import SchemaNode
 from jsonschema_path.typing import Schema
@@ -55,7 +57,20 @@ class CachedPathResolver:
             start = 0
             self.prefix_cache.seed_root(resolved)
         else:
-            start, resolved = cached_prefix
+            start, cached_resolved = cached_prefix
+            # Rebind to the current registry if it grew since this prefix
+            # was cached, then refresh the stored entry so subsequent hits
+            # skip the check. Reads of `_registry` go direct (cheap, plain
+            # attribute access on an attrs class); the cold-path write
+            # still goes through `rebind_resolved`.
+            current_registry = self.resolver._registry
+            if cached_resolved.resolver._registry is not current_registry:
+                cached_resolved = cast(
+                    Resolved[LookupNode],
+                    rebind_resolved(cached_resolved, current_registry),
+                )
+                self.prefix_cache.replace(parts_tuple, start, cached_resolved)
+            resolved = cached_resolved
             current_node = resolved.contents
             current_resolver = cast(Resolver[Schema], resolved.resolver)
 
@@ -83,9 +98,10 @@ class CachedPathResolver:
         if registry is self.resolver._registry:
             return False
 
-        self.resolver = self.resolver._evolve(
-            self.resolver._base_uri,
-            registry=registry,
+        # Rebind self.resolver so subsequent fresh resolutions start from
+        # the latest registry. The prefix cache is *not* invalidated; its
+        # entries are rebound on read in _resolve_with_prefix_cache above.
+        self.resolver = cast(
+            Resolver[Schema], rebind_registry(self.resolver, registry)
         )
-        self.prefix_cache.invalidate()
         return True

--- a/poetry.lock
+++ b/poetry.lock
@@ -1595,4 +1595,4 @@ requests = ["requests"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0.0"
-content-hash = "7827ad3deef0b8ae31b769b44e6d894dbcae39b518d70490fec10884b7965bde"
+content-hash = "9b8adbf4cf5176f7fde58c6ff59361b9276fed16fe5616e876fd979e9ab3dbfb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
+attrs = ">=22.2.0"
 pathable = "^0.5.0"
 python = ">=3.10,<4.0.0"
 PyYAML = ">=5.1"

--- a/tests/unit/test_accessors.py
+++ b/tests/unit/test_accessors.py
@@ -229,7 +229,7 @@ class TestSchemaAccessorResolvedCache:
 
         assert first_a is not second_a
 
-    def test_registry_evolution_invalidates_previous_generation(self):
+    def test_registry_evolution_rebinds_cached_resolved(self):
         retrieve = Mock(side_effect=[{"value": 1}, {"value": 2}])
         accessor = SchemaAccessor.from_schema(
             {
@@ -246,15 +246,47 @@ class TestSchemaAccessorResolvedCache:
 
         first_one = accessor.get_resolved(["one", "value"])
         assert first_one.contents == 1
+        registry_after_first = accessor._path_resolver.resolver._registry
+        assert first_one.resolver._registry is registry_after_first
 
         second_two = accessor.get_resolved(["two", "value"])
         assert second_two.contents == 2
+        registry_after_two = accessor._path_resolver.resolver._registry
+        assert registry_after_two is not registry_after_first
 
+        # Cache hit rebinds to the current registry instead of
+        # re-resolving from scratch: same underlying contents object,
+        # new Resolved wrapper carrying the up-to-date registry.
         second_one = accessor.get_resolved(["one", "value"])
         assert second_one.contents == 1
+        assert second_one.contents is first_one.contents
+        assert second_one.resolver._registry is registry_after_two
         assert second_one is not first_one
 
+        # No re-retrieval — each $ref target is loaded exactly once.
         assert retrieve.call_count == 2
+
+    def test_rebound_cache_hit_preserves_base_uri_and_previous(self):
+        retrieve = Mock(side_effect=[{"value": 1}, {"value": 2}])
+        accessor = SchemaAccessor.from_schema(
+            {
+                "one": {"$ref": "x://one"},
+                "two": {"$ref": "x://two"},
+            },
+            handlers={"x": retrieve},
+            resolved_cache_maxsize=8,
+        )
+
+        first_one = accessor.get_resolved(["one", "value"])
+        _ = accessor.get_resolved(["two", "value"])
+        rebound = accessor.get_resolved(["one", "value"])
+
+        # Rebind is a pure registry field swap. base_uri and the
+        # dynamic-scope `_previous` chain must survive intact, otherwise
+        # subsequent $ref resolution under the rebound Resolved would
+        # use the wrong scope.
+        assert rebound.resolver._base_uri == first_one.resolver._base_uri
+        assert rebound.resolver._previous == first_one.resolver._previous
 
 
 class TestSchemaAccessorPrefixCache:
@@ -300,7 +332,7 @@ class TestSchemaAccessorPrefixCache:
 
         assert first is not second
 
-    def test_prefix_cache_is_cleared_when_registry_evolves(self):
+    def test_prefix_cache_is_preserved_when_registry_evolves(self):
         retrieve = Mock(return_value={"value": "tested"})
         accessor = SchemaAccessor.from_schema(
             {
@@ -314,5 +346,44 @@ class TestSchemaAccessorPrefixCache:
 
         _ = accessor.get_resolved(["one", "value"])
 
+        # Prefix cache used to be wiped on registry growth. With the
+        # rebind-on-read strategy it retains its intermediate entry.
         assert accessor._path_resolver.prefix_cache is prefix_cache
-        assert accessor._path_resolver.prefix_cache._cache == {}
+        assert ("one",) in prefix_cache._cache
+
+    def test_prefix_cache_rebound_avoids_redundant_retrieval(self):
+        payloads = {
+            "x://one": {
+                "fast": "shallow",
+                "deep": {"$ref": "x://later"},
+            },
+            "x://primer": {"primed": {"$ref": "x://later"}},
+            "x://later": {"value": "found"},
+        }
+        retrieve = Mock(side_effect=lambda uri: payloads[uri])
+        accessor = SchemaAccessor.from_schema(
+            {
+                "one": {"$ref": "x://one"},
+                "primer": {"$ref": "x://primer"},
+            },
+            handlers={"x": retrieve},
+        )
+
+        # Populate the prefix cache for ("one",) under a registry that
+        # only knows x://one. Walking through "fast" avoids loading
+        # x://later at this point.
+        assert accessor.read(["one", "fast"]) == "shallow"
+
+        # Grow the registry through a different branch, loading
+        # x://primer and x://later.
+        assert accessor.read(["primer", "primed", "value"]) == "found"
+
+        # Re-enter through the cached ("one",) prefix and follow a
+        # $ref into x://later. Without rebind this would either fail
+        # (resource unknown to the stale registry) or trigger a
+        # second retrieve. With rebind it should reuse the already
+        # loaded x://later resource.
+        assert accessor.read(["one", "deep", "value"]) == "found"
+
+        calls = sorted(c.args[0] for c in retrieve.call_args_list)
+        assert calls == ["x://later", "x://one", "x://primer"]

--- a/tests/unit/test_referencing_compat.py
+++ b/tests/unit/test_referencing_compat.py
@@ -1,0 +1,135 @@
+"""Tests for the referencing compatibility shim.
+
+The shim is the single firewall against ``referencing`` private-API
+drift. These tests pin the behavior we depend on so that a future
+``referencing`` release that changes it produces a meaningful failure
+here rather than mysterious cache bugs elsewhere.
+"""
+
+from unittest.mock import patch
+
+import attrs
+import pytest
+from referencing import Registry
+from referencing._core import Resolved
+from referencing._core import Resolver
+from referencing.jsonschema import DRAFT202012
+
+from jsonschema_path._referencing_compat import assert_referencing_layout
+from jsonschema_path._referencing_compat import base_uri_of
+from jsonschema_path._referencing_compat import rebind_registry
+from jsonschema_path._referencing_compat import rebind_resolved
+from jsonschema_path._referencing_compat import registry_of
+
+
+def _build_resolver(resources):
+    registry = Registry()
+    for uri, doc in resources.items():
+        registry = registry.with_resource(
+            uri, DRAFT202012.create_resource(doc)
+        )
+    base_uri = next(iter(resources)) if resources else ""
+    return registry.resolver(base_uri=base_uri), registry
+
+
+class TestRebindRegistry:
+    def test_swaps_registry_only(self):
+        resolver, reg1 = _build_resolver({"a://1": {"v": 1}})
+        reg2 = reg1.with_resource(
+            "a://2", DRAFT202012.create_resource({"v": 2})
+        )
+
+        new_resolver = rebind_registry(resolver, reg2)
+
+        assert new_resolver._registry is reg2
+        # base_uri and dynamic-scope previous chain must be untouched
+        # — that is the *whole point* of using attrs.evolve rather than
+        # Resolver._evolve (which would push to _previous on a
+        # differing base_uri).
+        assert new_resolver._base_uri == resolver._base_uri
+        assert new_resolver._previous == resolver._previous
+
+    def test_rebound_resolver_sees_new_resources(self):
+        resolver, reg1 = _build_resolver({"a://1": {"v": 1}})
+        reg2 = reg1.with_resource(
+            "a://2", DRAFT202012.create_resource({"v": 2})
+        )
+
+        rebound = rebind_registry(resolver, reg2)
+        looked_up = rebound.lookup("a://2")
+
+        assert looked_up.contents == {"v": 2}
+
+    def test_original_resolver_unchanged(self):
+        resolver, reg1 = _build_resolver({"a://1": {"v": 1}})
+        reg2 = reg1.with_resource(
+            "a://2", DRAFT202012.create_resource({"v": 2})
+        )
+
+        _ = rebind_registry(resolver, reg2)
+
+        # attrs.evolve must not mutate the source.
+        assert resolver._registry is reg1
+
+
+class TestRebindResolved:
+    def test_preserves_contents_swaps_registry(self):
+        resolver, reg1 = _build_resolver({"a://1": {"v": 1}})
+        resolved = resolver.lookup("a://1")
+        reg2 = reg1.with_resource(
+            "a://2", DRAFT202012.create_resource({"v": 2})
+        )
+
+        rebound = rebind_resolved(resolved, reg2)
+
+        assert rebound.contents is resolved.contents
+        assert rebound.resolver._registry is reg2
+        # Source must not be mutated.
+        assert resolved.resolver._registry is reg1
+
+
+class TestRegistryOf:
+    def test_for_resolver(self):
+        resolver, reg = _build_resolver({"a://1": {"v": 1}})
+
+        assert registry_of(resolver) is reg
+
+    def test_for_resolved(self):
+        resolver, reg = _build_resolver({"a://1": {"v": 1}})
+        resolved = resolver.lookup("a://1")
+
+        assert isinstance(resolved, Resolved)
+        assert registry_of(resolved) is resolved.resolver._registry
+
+
+class TestBaseUriOf:
+    def test_for_resolver(self):
+        resolver, _ = _build_resolver({"a://1": {"v": 1}})
+
+        assert base_uri_of(resolver) == "a://1"
+
+    def test_for_resolved(self):
+        resolver, _ = _build_resolver({"a://1": {"v": 1}})
+        resolved = resolver.lookup("a://1")
+
+        assert base_uri_of(resolved) == resolved.resolver._base_uri
+
+
+class TestAssertReferencingLayout:
+    def test_passes_with_current_referencing(self):
+        # Must not raise under the supported referencing range.
+        assert_referencing_layout()
+
+    def test_raises_when_required_field_missing(self):
+        # Simulate a future referencing that renames _registry. The
+        # shim must surface a clear ImportError rather than letting
+        # silent wrong-results escape into production.
+        fake_fields = tuple(
+            f for f in attrs.fields(Resolver) if f.name != "_registry"
+        )
+        with patch(
+            "jsonschema_path._referencing_compat.attrs.fields",
+            return_value=fake_fields,
+        ):
+            with pytest.raises(ImportError, match="referencing"):
+                assert_referencing_layout()


### PR DESCRIPTION
## Rebind cached `Resolved`s to the current registry on read

Instead of throwing entries away, when a cache hit happens, re-`_evolve` the stored resolver onto the latest registry before returning. That works because we trust, that the resolver's position (its base URI, anchor stack) is still valid under the new registry, since registries grow monotonically and existing resources aren't displaced. The reason it wasn't done before is that `Resolved` and `Resolver` are `referencing` internals (note the `_evolve`, `_registry`, `_base_uri` underscores), so reaching in to rebuild them on every hit is fragile.